### PR TITLE
Elementwise absolute value builtin

### DIFF
--- a/dagrt/data.py
+++ b/dagrt/data.py
@@ -371,7 +371,12 @@ class KindInferenceMapper(Mapper):
             except UnableToInferKind:
                 arg_kinds[key] = None
 
-        z = func.get_result_kinds(arg_kinds, self.check)
+        try:
+            z = func.get_result_kinds(arg_kinds, self.check)
+        except Exception:
+            raise UnableToInferKind(
+                    "function '%s' needs more info about arguments"
+                    % function_id)
 
         if single_return_only:
             if len(z) != 1:

--- a/test/test_element_abs.f90
+++ b/test/test_element_abs.f90
@@ -1,0 +1,31 @@
+program test_element_abs
+
+  use element_abs_test, only: dagrt_state_type, &
+    timestep_initialize => initialize, &
+    timestep_run => run, &
+    timestep_shutdown => shutdown
+
+  implicit none
+
+  type(dagrt_state_type), target :: dagrt_state
+  type(dagrt_state_type), pointer :: dagrt_state_ptr
+
+  real*8, dimension(100) :: y0
+
+  integer i
+
+  ! start code ----------------------------------------------------------------
+
+  dagrt_state_ptr => dagrt_state
+
+
+  do i = 1, 100
+    y0 = i
+  end do
+
+  call timestep_initialize(dagrt_state=dagrt_state_ptr, state_ytype=y0)
+  call timestep_run(dagrt_state=dagrt_state_ptr)
+  call timestep_shutdown(dagrt_state=dagrt_state_ptr)
+
+end program
+


### PR DESCRIPTION
Adds an elementwise absolute value builtin function that operates on scalars, arrays, and usertypes. Stepping stone towards the weighted root-mean-square norms used by [this PR](https://github.com/inducer/leap/pull/17).