### PR TITLE
Fix flake8 issues

### DIFF
--- a/dagrt/codegen/analysis.py
+++ b/dagrt/codegen/analysis.py
@@ -23,7 +23,8 @@ THE SOFTWARE.
 """
 
 from pymbolic.mapper import Collector
-from dagrt.language import YieldState, SwitchPhase, AssignFunctionCall
+
+from dagrt.language import AssignFunctionCall, SwitchPhase, YieldState
 
 
 # {{{ verifier

--- a/dagrt/codegen/codegen_base.py
+++ b/dagrt/codegen/codegen_base.py
@@ -22,8 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from dagrt.codegen.dag_ast import \
-        Block, IfThen, IfThenElse, StatementWrapper, ForLoop
+from dagrt.codegen.dag_ast import (
+    Block, ForLoop, IfThen, IfThenElse, StatementWrapper)
 
 
 class StructuredCodeGenerator:

--- a/dagrt/codegen/dag_ast.py
+++ b/dagrt/codegen/dag_ast.py
@@ -22,10 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from pymbolic.mapper import IdentityMapper, Collector
+from pymbolic.mapper import Collector, IdentityMapper
 from pymbolic.mapper.stringifier import StringifyMapper
 from pymbolic.primitives import Expression, LogicalNot
-from dagrt.language import Nop, Assign
+
+from dagrt.language import Assign, Nop
 
 
 # {{{ ast node types

--- a/dagrt/codegen/expressions.py
+++ b/dagrt/codegen/expressions.py
@@ -1,7 +1,8 @@
 """Code generation of expressions"""
-from pymbolic.mapper.stringifier import (
-        StringifyMapper, PREC_NONE, PREC_CALL, PREC_PRODUCT, PREC_LOGICAL_OR)
 import numpy as np
+
+from pymbolic.mapper.stringifier import (
+    PREC_CALL, PREC_LOGICAL_OR, PREC_NONE, PREC_PRODUCT, StringifyMapper)
 
 
 __copyright__ = "Copyright (C) 2014 Matt Wala"

--- a/dagrt/codegen/fortran.py
+++ b/dagrt/codegen/fortran.py
@@ -22,22 +22,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import re  # noqa
 import sys
 from functools import partial
-import re  # noqa
 
-from dagrt.codegen.expressions import FortranExpressionMapper
-from dagrt.codegen.codegen_base import StructuredCodeGenerator
-from dagrt.utils import is_state_variable
-from dagrt.data import UserType
-from pytools.py_codegen import (
-        # It's the same code. So sue me.
-        PythonCodeGenerator as FortranEmitterBase)
-from pymbolic.primitives import (Call, CallWithKwargs, Variable,
-        Subscript, Lookup)
 from pymbolic.mapper import IdentityMapper
-from dagrt.codegen.utils import (wrap_line_base, KeyToUniqueNameMap,
-        make_identifier_from_name)
+from pymbolic.primitives import Call, CallWithKwargs, Lookup, Subscript, Variable
+from pytools.py_codegen import (  # It's the same code. So sue me.
+    PythonCodeGenerator as FortranEmitterBase)
+
+from dagrt.codegen.codegen_base import StructuredCodeGenerator
+from dagrt.codegen.expressions import FortranExpressionMapper
+from dagrt.codegen.utils import (
+    KeyToUniqueNameMap, make_identifier_from_name, wrap_line_base)
+from dagrt.data import UserType
+from dagrt.utils import is_state_variable
 
 
 __doc__ = """
@@ -240,8 +239,7 @@ class CallCode:
     def __call__(self, results, function, args, arg_kinds,
             code_generator):
         from dagrt.codegen.utils import (
-                remove_common_indentation,
-                remove_redundant_blank_lines)
+            remove_common_indentation, remove_redundant_blank_lines)
 
         def add_declaration(decl):
             code_generator.declaration_emitter(decl)
@@ -1054,19 +1052,17 @@ class CodeGenerator(StructuredCodeGenerator):
 
         # {{{ produce function name / function AST pairs
 
-        from dagrt.codegen.dag_ast import (
-                create_ast_from_phase, get_statements_in_ast)
-
         from collections import namedtuple
+
+        from dagrt.codegen.dag_ast import (
+            create_ast_from_phase, get_statements_in_ast)
         NameASTPair = namedtuple("NameASTPair", "name, ast")  # noqa
         fdescrs = []
 
         def process_ast(ast, print_ast=False):
             from dagrt.codegen.transform import (
-                    eliminate_self_dependencies,
-                    isolate_function_arguments,
-                    isolate_function_calls,
-                    expand_IfThenElse)
+                eliminate_self_dependencies, expand_IfThenElse,
+                isolate_function_arguments, isolate_function_calls)
             ast = eliminate_self_dependencies(ast)
             ast = isolate_function_arguments(ast)
             ast = isolate_function_calls(ast)
@@ -1083,8 +1079,8 @@ class CodeGenerator(StructuredCodeGenerator):
 
         # }}}
 
-        from dagrt.data import SymbolKindFinder, Integer
         from dagrt.codegen.dag_ast import LoopVariableFinder
+        from dagrt.data import Integer, SymbolKindFinder
 
         self.sym_kind_table = SymbolKindFinder(self.function_registry)(
                 [fd.name for fd in fdescrs],
@@ -1095,8 +1091,8 @@ class CodeGenerator(StructuredCodeGenerator):
                     for loop_var in LoopVariableFinder()(fd.ast)])
 
         from dagrt.codegen.analysis import (
-                collect_ode_component_names_from_dag,
-                var_to_last_dependent_statement_mapping)
+            collect_ode_component_names_from_dag,
+            var_to_last_dependent_statement_mapping)
 
         component_ids = collect_ode_component_names_from_dag(dag)
 
@@ -1456,7 +1452,7 @@ class CodeGenerator(StructuredCodeGenerator):
         if emit is None:
             emit = self.emit
 
-        from dagrt.data import Boolean, Scalar, Array, Integer
+        from dagrt.data import Array, Boolean, Integer, Scalar
 
         type_specifiers = other_specifiers
 
@@ -2094,7 +2090,7 @@ class CodeGenerator(StructuredCodeGenerator):
         self.emitter.__exit__(None, None, None)
 
     def emit_assign_expr(self, assignee_sym, assignee_subscript, expr):
-        from dagrt.data import UserType, Array
+        from dagrt.data import Array, UserType
 
         assignee_fortran_name = self.name_manager[assignee_sym]
 
@@ -2185,8 +2181,9 @@ class CodeGenerator(StructuredCodeGenerator):
             except KeyError:
                 pass
 
-        from pymbolic.mapper.dependency import DependencyMapper
         from pymbolic import var
+        from pymbolic.mapper.dependency import DependencyMapper
+
         from dagrt.data import UserType
 
         for assignee_sym in inst.assignees:
@@ -2241,8 +2238,9 @@ class CodeGenerator(StructuredCodeGenerator):
                 (),
                 inst.time)
 
-        from dagrt.language import AssignFunctionCall
         from pymbolic import var
+
+        from dagrt.language import AssignFunctionCall
 
         if self.call_before_state_update:
             self.emit_inst_AssignFunctionCall(
@@ -2339,7 +2337,7 @@ def codegen_builtin_norm_2(results, function, args, arg_kinds,
         code_generator):
     result, = results
 
-    from dagrt.data import Scalar, UserType, Array
+    from dagrt.data import Array, Scalar, UserType
     x_kind = arg_kinds[0]
     if isinstance(x_kind, Scalar):
         if x_kind.is_real_valued:
@@ -2382,7 +2380,7 @@ def codegen_builtin_len(results, function, args, arg_kinds,
         code_generator):
     result, = results
 
-    from dagrt.data import Scalar, Array, UserType
+    from dagrt.data import Array, Scalar, UserType
     x_kind = arg_kinds[0]
     if isinstance(x_kind, Scalar):
         if x_kind.is_real_valued:
@@ -2421,7 +2419,7 @@ def codegen_builtin_elementwise_abs(results, function, args, arg_kinds,
         code_generator):
     result, = results
 
-    from dagrt.data import Scalar, Array, UserType
+    from dagrt.data import Array, Scalar, UserType
     x_kind = arg_kinds[0]
     if isinstance(x_kind, Scalar) or isinstance(x_kind, Array):
         code_generator.emit("{result} = abs({arg})".format(

--- a/dagrt/codegen/python.py
+++ b/dagrt/codegen/python.py
@@ -26,16 +26,18 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from dagrt.codegen.expressions import PythonExpressionMapper
-from dagrt.codegen.codegen_base import StructuredCodeGenerator
-from dagrt.codegen.utils import (wrap_line_base, exec_in_new_namespace,
-                    KeyToUniqueNameMap)
-from pytools.py_codegen import (
-        PythonCodeGenerator as PythonEmitter,
-        PythonFunctionGenerator as PythonFunctionEmitter)
-from dagrt.utils import is_state_variable
-from functools import partial
 from abc import ABC, abstractmethod
+from functools import partial
+
+from pytools.py_codegen import (
+    PythonCodeGenerator as PythonEmitter,
+    PythonFunctionGenerator as PythonFunctionEmitter)
+
+from dagrt.codegen.codegen_base import StructuredCodeGenerator
+from dagrt.codegen.expressions import PythonExpressionMapper
+from dagrt.codegen.utils import (
+    KeyToUniqueNameMap, exec_in_new_namespace, wrap_line_base)
+from dagrt.utils import is_state_variable
 
 
 def pad_python(line, width):
@@ -279,8 +281,8 @@ class CodeGenerator(StructuredCodeGenerator):
 
     def _pre_lower(self, ast):
         self._has_yield_inst = False
-        from dagrt.language import YieldState
         from dagrt.codegen.dag_ast import get_statements_in_ast
+        from dagrt.language import YieldState
         for inst in get_statements_in_ast(ast):
             if isinstance(inst, YieldState):
                 self._has_yield_inst = True
@@ -323,6 +325,7 @@ class CodeGenerator(StructuredCodeGenerator):
             emit(line)
 
         from inspect import getsourcefile
+
         import dagrt.builtins_python as builtins
         builtins_source_file = getsourcefile(builtins)
 

--- a/dagrt/codegen/transform.py
+++ b/dagrt/codegen/transform.py
@@ -25,9 +25,10 @@ THE SOFTWARE.
 
 from pymbolic.mapper import IdentityMapper
 from pytools import UniqueNameGenerator
+
 from dagrt.codegen.dag_ast import (
-        ASTIdentityMapper, get_statements_in_ast,
-        Block, StatementWrapper)
+    ASTIdentityMapper, Block, StatementWrapper, get_statements_in_ast)
+
 
 __doc__ = """
 .. autofunction:: eliminate_self_dependencies
@@ -95,8 +96,9 @@ class SelfDependencyEliminator(ASTStatementRewriter):
         tmp_stmt_ids = []
 
         new_statements = []
-        from dagrt.language import Assign
         from pymbolic import var
+
+        from dagrt.language import Assign
         for var_name in read_and_written:
             tmp_var_name = self.var_name_gen(
                     "temp_"
@@ -330,8 +332,8 @@ class ExprIfThenElseExpander(IdentityMapper):
         self.var_name_gen = var_name_gen
 
     def map_if(self, expr, base_condition, base_deps, extra_deps):
-        from pymbolic.primitives import LogicalNot
         from pymbolic import var
+        from pymbolic.primitives import LogicalNot
 
         flag = var(self.var_name_gen("<cond>ifthenelse_cond"))
         tmp_result = self.var_name_gen("ifthenelse_result")

--- a/dagrt/codegen/utils.py
+++ b/dagrt/codegen/utils.py
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 import functools
 import shlex
+
 from pytools import UniqueNameGenerator
 
 

--- a/dagrt/data.py
+++ b/dagrt/data.py
@@ -79,7 +79,7 @@ class SymbolKind(RecordWithoutPickling):
 
     def __eq__(self, other):
         return (
-                type(self) == type(other)
+                type(self) is type(other)
                 and self.__getinitargs__() == other.__getinitargs__())
 
     def __ne__(self, other):

--- a/dagrt/data.py
+++ b/dagrt/data.py
@@ -25,12 +25,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from dagrt.utils import TODO
+from pymbolic.mapper import Mapper
+from pytools import RecordWithoutPickling
 
 import dagrt.language as lang
-from dagrt.utils import is_state_variable
-from pytools import RecordWithoutPickling
-from pymbolic.mapper import Mapper
+from dagrt.utils import TODO, is_state_variable
 
 
 __doc__ = """

--- a/dagrt/exec_numpy.py
+++ b/dagrt/exec_numpy.py
@@ -21,6 +21,7 @@ THE SOFTWARE.
 """
 
 from collections import namedtuple
+
 from dagrt.expression import EvaluationMapper
 
 

--- a/dagrt/expression.py
+++ b/dagrt/expression.py
@@ -23,19 +23,19 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from pymbolic.mapper.evaluator import EvaluationMapper as EvaluationMapperBase
-from pymbolic.mapper.dependency import DependencyMapper
-from pymbolic.mapper import CombineMapper, IdentityMapper
-from pymbolic.mapper.unifier import UnidirectionalUnifier
-from pymbolic.primitives import Variable, is_constant
-from pymbolic.parser import Parser, _less, _greater, _identifier
-from pymbolic.primitives import If as IfThenElse # noqa
-from pymbolic.mapper.stringifier import PREC_LOGICAL_OR
-
 import logging
 import operator
-import pytools.lex
 from functools import reduce
+
+import pytools.lex
+from pymbolic.mapper import CombineMapper, IdentityMapper
+from pymbolic.mapper.dependency import DependencyMapper
+from pymbolic.mapper.evaluator import EvaluationMapper as EvaluationMapperBase
+from pymbolic.mapper.stringifier import PREC_LOGICAL_OR
+from pymbolic.mapper.unifier import UnidirectionalUnifier
+from pymbolic.parser import Parser, _greater, _identifier, _less
+from pymbolic.primitives import If as IfThenElse, Variable, is_constant  # noqa
+
 
 logger = logging.getLogger(__name__)
 

--- a/dagrt/function_registry.py
+++ b/dagrt/function_registry.py
@@ -25,8 +25,9 @@ THE SOFTWARE.
 
 
 from pytools import RecordWithoutPickling
-from dagrt.data import (
-        UserType, Integer, Boolean, Scalar, Array, UnableToInferKind)
+
+from dagrt.data import Array, Boolean, Integer, Scalar, UnableToInferKind, UserType
+
 
 NoneType = type(None)
 

--- a/dagrt/language.py
+++ b/dagrt/language.py
@@ -23,18 +23,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from pytools import RecordWithoutPickling, memoize_method, natsorted
+import logging
+from contextlib import contextmanager
+from sys import intern
+
 from pymbolic.imperative.statement import (
-        ConditionalStatement as StatementBase,
-        ConditionalAssignment as AssignBase,
-        Nop as NopBase)
+    ConditionalAssignment as AssignBase, ConditionalStatement as StatementBase,
+    Nop as NopBase)
+from pytools import RecordWithoutPickling, memoize_method, natsorted
 
 from dagrt.utils import get_variables
-from contextlib import contextmanager
-
-import logging
-
-from sys import intern
 
 
 logger = logging.getLogger(__name__)
@@ -246,7 +244,7 @@ class Assign(Statement, AssignBase):
 
     @property
     def assignee(self):
-        from pymbolic.primitives import Variable, Subscript
+        from pymbolic.primitives import Subscript, Variable
         if isinstance(self.lhs, Variable):
             return self.lhs.name
         elif isinstance(self.lhs, Subscript):
@@ -257,7 +255,7 @@ class Assign(Statement, AssignBase):
 
     @property
     def assignee_subscript(self):
-        from pymbolic.primitives import Variable, Subscript
+        from pymbolic.primitives import Subscript, Variable
         if isinstance(self.lhs, Variable):
             return ()
         elif isinstance(self.lhs, Subscript):
@@ -1075,7 +1073,7 @@ class CodeBuilder:
                         "%d found" % len(assignees))
             assignee, = assignees
 
-            from pymbolic.primitives import Variable, Subscript
+            from pymbolic.primitives import Subscript, Variable
             if isinstance(assignee, Variable):
                 aname = assignee.name
                 asub = ()

--- a/dagrt/utils.py
+++ b/dagrt/utils.py
@@ -120,56 +120,6 @@ def resolve_args(arg_names, default_dict, arg_dict):
 # }}}
 
 
-# {{{ temporary directory
-
-class TemporaryDirectory:
-    """Create and return a temporary directory.  This has the same
-    behavior as mkdtemp but can be used as a context manager.  For
-    example:
-
-        with TemporaryDirectory() as tmpdir:
-            ...
-
-    Upon exiting the context, the directory and everything contained
-    in it are removed.
-    """
-
-    # Yanked from
-    # https://hg.python.org/cpython/file/3.3/Lib/tempfile.py
-
-    # Handle mkdtemp raising an exception
-    name = None
-    _closed = False
-
-    def __init__(self, suffix="", prefix="tmp", dirname=None):
-        from tempfile import mkdtemp
-        self.name = mkdtemp(suffix, prefix, dirname)
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} {self.name!r}>"
-
-    def __enter__(self):
-        return self.name
-
-    def cleanup(self, _warn=False):
-        import warnings
-        if self.name and not self._closed:
-            from shutil import rmtree
-            rmtree(self.name)
-            self._closed = True
-            if _warn and warnings.warn:
-                warnings.warn(f"Implicitly cleaning up {self!r}")
-
-    def __exit__(self, exc, value, tb):
-        self.cleanup()
-
-    def __del__(self):
-        # Issue a ResourceWarning if implicit cleanup needed
-        self.cleanup(_warn=True)
-
-# }}}
-
-
 # {{{ run_fortran
 
 class DebuggerExit(Exception):
@@ -183,6 +133,7 @@ def run_fortran(sources, fortran_options=None, fortran_libraries=None, debug=Fal
         fortran_libraries = []
 
     from os.path import join
+    from tempfile import TemporaryDirectory
 
     with TemporaryDirectory() as tmpdir:
         source_names = []

--- a/dagrt/utils.py
+++ b/dagrt/utils.py
@@ -193,7 +193,7 @@ def run_fortran(sources, fortran_options=None, fortran_libraries=None, debug=Fal
                 srcf.write(contents)
 
         import os
-        from subprocess import check_call, Popen, PIPE
+        from subprocess import PIPE, Popen, check_call
         check_call(
                 [os.environ.get("FC", "gfortran"),
                     "-Wall",

--- a/examples/adaptive_rk.py
+++ b/examples/adaptive_rk.py
@@ -25,8 +25,9 @@ THE SOFTWARE.
 
 import numpy as np
 
-from dagrt.language import DAGCode, CodeBuilder
 from pymbolic import var
+
+from dagrt.language import CodeBuilder, DAGCode
 
 
 def adaptive_rk_method(tol):

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,11 @@ docstring-quotes = """
 multiline-quotes = """
 
 # enable-flake8-bugbear
+
+[isort]
+known_firstparty=pytools,pymbolic
+known_local_folder=dagrt
+line_length = 85
+lines_after_imports = 2
+combine_as_imports = True
+multi_line_output = 4

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,9 +27,7 @@ import pytest
 def python_method_impl(request):
     kind = request.param
 
-    from utils import (
-            python_method_impl_interpreter,
-            python_method_impl_codegen)
+    from utils import python_method_impl_codegen, python_method_impl_interpreter
     if kind == "interpreter":
         return python_method_impl_interpreter
     elif kind == "codegen":

--- a/test/test_ast.py
+++ b/test/test_ast.py
@@ -23,17 +23,15 @@ THE SOFTWARE.
 
 import sys
 
-from pymbolic import var
-
-from pymbolic.primitives import LogicalNot
-
-from dagrt.codegen.dag_ast import (IfThen, IfThenElse, Block, StatementWrapper,
-                               create_ast_from_phase, simplify_ast)
-from dagrt.language import Statement
-
+import pytest
 from utils import create_DAGCode_with_steady_phase
 
-import pytest
+from pymbolic import var
+from pymbolic.primitives import LogicalNot
+
+from dagrt.codegen.dag_ast import (
+    Block, IfThen, IfThenElse, StatementWrapper, create_ast_from_phase, simplify_ast)
+from dagrt.language import Statement
 
 
 def test_create_ast():

--- a/test/test_builtins.py
+++ b/test/test_builtins.py
@@ -22,19 +22,18 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np
-import pytest
 import sys
 
-from dagrt.language import Assign, YieldState
+import numpy as np
+import pytest
+from utils import (  # noqa
+    RawCodeBuilder, create_DAGCode_with_steady_phase,
+    execute_and_return_single_result, python_method_impl_codegen as pmi_cg,
+    python_method_impl_interpreter as pmi_int)
+
 from pymbolic import var
 
-from utils import (  # noqa
-        execute_and_return_single_result,
-        RawCodeBuilder,
-        python_method_impl_interpreter as pmi_int,
-        python_method_impl_codegen as pmi_cg,
-        create_DAGCode_with_steady_phase)
+from dagrt.language import Assign, YieldState
 
 
 @pytest.mark.parametrize(("obj, len_"), [(np.ones(0), 0),

--- a/test/test_code_builder.py
+++ b/test/test_code_builder.py
@@ -1,19 +1,16 @@
 #! /usr/bin/env python
 
 import sys
-from dagrt.language import (CodeBuilder, DAGCode)
-from pymbolic import var
-
-from dagrt.exec_numpy import NumpyInterpreter  # noqa
-from dagrt.codegen import PythonCodeGenerator  # noqa
 
 from utils import (  # noqa
-        python_method_impl_interpreter as pmi_int,
-        python_method_impl_codegen as pmi_cg)
+    create_DAGCode_with_steady_phase, execute_and_return_single_result,
+    python_method_impl_codegen as pmi_cg, python_method_impl_interpreter as pmi_int)
 
-from utils import (
-        execute_and_return_single_result,
-        create_DAGCode_with_steady_phase)
+from pymbolic import var
+
+from dagrt.codegen import PythonCodeGenerator  # noqa
+from dagrt.exec_numpy import NumpyInterpreter  # noqa
+from dagrt.language import CodeBuilder, DAGCode
 
 
 __copyright__ = "Copyright (C) 2014 Matt Wala"

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -1,18 +1,17 @@
 #! /usr/bin/env python
 
-import pytest
 import sys
 
-from dagrt.language import Assign, YieldState
-from dagrt.codegen import CodeGenerationError
-from dagrt.codegen.analysis import verify_code
+import pytest
+from utils import (
+    RawCodeBuilder, create_DAGCode_with_init_and_main_phases,
+    create_DAGCode_with_steady_phase)
 
 from pymbolic import var
 
-from utils import (
-        RawCodeBuilder,
-        create_DAGCode_with_init_and_main_phases,
-        create_DAGCode_with_steady_phase)
+from dagrt.codegen import CodeGenerationError
+from dagrt.codegen.analysis import verify_code
+from dagrt.language import Assign, YieldState
 
 
 __copyright__ = "Copyright (C) 2014 Andreas Kloeckner, Matt Wala"

--- a/test/test_codegen_fortran.py
+++ b/test/test_codegen_fortran.py
@@ -24,21 +24,18 @@ THE SOFTWARE.
 
 import sys
 
-from dagrt.language import YieldState
-from dagrt.language import CodeBuilder
+from utils import RawCodeBuilder, create_DAGCode_with_steady_phase
+
 import dagrt.codegen.fortran as f
-
-from utils import RawCodeBuilder
-
+from dagrt.language import CodeBuilder, YieldState
 from dagrt.utils import run_fortran
 
-from utils import create_DAGCode_with_steady_phase
 
 #skip = pytest.mark.skipif(True, reason="not fully implemented")
 
 
 def read_file(rel_path):
-    from os.path import join, abspath, dirname
+    from os.path import abspath, dirname, join
     path = join(abspath(dirname(__file__)), rel_path)
     with open(path) as inf:
         return inf.read()
@@ -126,8 +123,7 @@ def test_self_dep_in_loop():
 
     rhs_function = "<func>f"
 
-    from dagrt.function_registry import (
-            base_function_registry, register_ode_rhs)
+    from dagrt.function_registry import base_function_registry, register_ode_rhs
     freg = register_ode_rhs(base_function_registry, "ytype",
                             identifier=rhs_function,
                             input_names=("y",))
@@ -181,8 +177,7 @@ def test_elementwise_abs():
 
     rhs_function = "<func>f"
 
-    from dagrt.function_registry import (
-            base_function_registry, register_ode_rhs)
+    from dagrt.function_registry import base_function_registry, register_ode_rhs
     freg = register_ode_rhs(base_function_registry, "ytype",
                             identifier=rhs_function,
                             input_names=("y",))

--- a/test/test_codegen_python.py
+++ b/test/test_codegen_python.py
@@ -23,21 +23,20 @@ THE SOFTWARE.
 """
 
 import sys
-import pytest
 
-import numpy.linalg as la
 import numpy as np
+import numpy.linalg as la
+import pytest
+from utils import (  # noqa
+    RawCodeBuilder, create_DAGCode_with_init_and_main_phases,
+    create_DAGCode_with_steady_phase, python_method_impl_codegen as pmi_cg,
+    python_method_impl_interpreter as pmi_int)
 
-from dagrt.language import Assign, YieldState, FailStep, Raise, Nop
-from dagrt.language import CodeBuilder, DAGCode
-from dagrt.codegen import PythonCodeGenerator
 from pymbolic import var
 
-from utils import (  # noqa
-        RawCodeBuilder, python_method_impl_interpreter as pmi_int,
-        python_method_impl_codegen as pmi_cg,
-        create_DAGCode_with_init_and_main_phases,
-        create_DAGCode_with_steady_phase)
+from dagrt.codegen import PythonCodeGenerator
+from dagrt.language import (
+    Assign, CodeBuilder, DAGCode, FailStep, Nop, Raise, YieldState)
 
 
 def test_basic_codegen():
@@ -416,8 +415,8 @@ def test_class_preamble():
 
     code = create_DAGCode_with_steady_phase(cb.statements)
 
-    from dagrt.codegen import PythonCodeGenerator
     import dagrt.function_registry as freg
+    from dagrt.codegen import PythonCodeGenerator
 
     preamble = """
             @staticmethod

--- a/test/test_expressions.py
+++ b/test/test_expressions.py
@@ -64,8 +64,9 @@ def test_match():
 
 
 def test_match_strings():
-    from dagrt.expression import match
     from pymbolic import var
+
+    from dagrt.expression import match
     subst = match("a+b*a", "a+b*a")
     assert len(subst) == 2
     assert subst["a"] == var("a")
@@ -143,6 +144,7 @@ def test_substitute():
 
 def test_parser():
     from pymbolic import var
+
     from dagrt.expression import parse
     parse("(2*a[1]*b[1]+2*a[0]*b[0])*(hankel_1(-1,sqrt(a[1]**2+a[0]**2)*k) "
             "-hankel_1(1,sqrt(a[1]**2+a[0]**2)*k))*k /(4*sqrt(a[1]**2+a[0]**2)) "

--- a/test/utils.py
+++ b/test/utils.py
@@ -23,6 +23,7 @@ THE SOFTWARE.
 """
 
 import numpy as np  # noqa
+
 import dagrt.language as lang
 
 


### PR DESCRIPTION
Went ahead and also enabled `flake8-isort` and removed `dagrt.utils.TemporaryDirectory` (seemed to be from a time before bumping to python 3.8) which had a `flake8-bugbear` error.